### PR TITLE
Add vim-style Ctrl navigation for [[page]] autocomplete

### DIFF
--- a/src/components/full-results-popup/components/chat/ChatCommandSuggest.tsx
+++ b/src/components/full-results-popup/components/chat/ChatCommandSuggest.tsx
@@ -325,13 +325,22 @@ const ChatCommandSuggest: React.FC<ChatCommandSuggestProps> = ({
     if (!isSlashMode) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "ArrowDown") {
+      // Ctrl+J/N (next) and Ctrl+K/P (prev) override browser shortcuts
+      // (e.g. Ctrl+N=new window, Ctrl+P=print) while the command suggest popup is open
+      const isCtrlOnly = e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey;
+      const normalizedKey = isCtrlOnly ? e.key.toLowerCase() : "";
+      const isVimNext =
+        isCtrlOnly && (normalizedKey === "j" || normalizedKey === "n");
+      const isVimPrev =
+        isCtrlOnly && (normalizedKey === "k" || normalizedKey === "p");
+
+      if (e.key === "ArrowDown" || isVimNext) {
         e.preventDefault();
         e.stopPropagation();
         setActiveIndex((prev) =>
           Math.min(prev + 1, slashModeFlatItems.length - 1),
         );
-      } else if (e.key === "ArrowUp") {
+      } else if (e.key === "ArrowUp" || isVimPrev) {
         e.preventDefault();
         e.stopPropagation();
         setActiveIndex((prev) => Math.max(prev - 1, 0));

--- a/src/components/full-results-popup/components/chat/ChatPageAutocomplete.tsx
+++ b/src/components/full-results-popup/components/chat/ChatPageAutocomplete.tsx
@@ -32,11 +32,12 @@ const ChatPageAutocomplete: React.FC<ChatPageAutocompleteProps> = ({
   // Handle keyboard navigation
   React.useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      const normalizedKey = e.key.toLowerCase();
-      const isVimNext =
-        e.ctrlKey && !e.metaKey && !e.altKey && (normalizedKey === "j" || normalizedKey === "n");
-      const isVimPrev =
-        e.ctrlKey && !e.metaKey && !e.altKey && (normalizedKey === "k" || normalizedKey === "p");
+      // Ctrl+J/N (next) and Ctrl+K/P (prev) override browser shortcuts
+      // (e.g. Ctrl+N=new window, Ctrl+P=print) while the autocomplete popup is open
+      const isCtrlOnly = e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey;
+      const normalizedKey = isCtrlOnly ? e.key.toLowerCase() : "";
+      const isVimNext = isCtrlOnly && (normalizedKey === "j" || normalizedKey === "n");
+      const isVimPrev = isCtrlOnly && (normalizedKey === "k" || normalizedKey === "p");
 
       if (e.key === "ArrowDown" || isVimNext) {
         e.preventDefault();


### PR DESCRIPTION
## Summary
- add vim-style page autocomplete navigation in chat when `[[...]]` suggestions are open
- support `Ctrl+J` and `Ctrl+N` for next item
- support `Ctrl+K` and `Ctrl+P` for previous item
- keep existing `ArrowUp`/`ArrowDown`, `Enter`/`Tab`, and `Escape` behavior

## Why
Roam users with vim-style habits expect these control-key combos to navigate suggestion lists.

## Scope
- `src/components/full-results-popup/components/chat/ChatPageAutocomplete.tsx`
