### PR TITLE
UI polish for chat: reset icon, code copy button, tooltip/toolbar consistency, and # page autocomplete

### DIFF
--- a/extension.css
+++ b/extension.css
@@ -2772,12 +2772,9 @@ h3.full-results-title.bp3-heading {
 
 .full-results-chat-assistant-message.chat-help {
   background: var(--bc-main, rgba(255, 255, 255, 0.5));
-  opacity: 0.65;
+  opacity: 1;
   border: 1px dashed #9e9e9e;
   box-shadow: 0 2px 6px #9e9e9e;
-}
-.full-results-chat-assistant-message.chat-help:hover {
-  opacity: 1;
 }
 .full-results-chat-assistant-message.chat-help .full-results-chat-suggestions {
   padding-top: 0;
@@ -2968,6 +2965,45 @@ html.has-blueprint-extension .full-results-chat-assistant-message.chat-help {
 
 .full-results-chat-text br {
   margin-bottom: 4px;
+}
+
+/* Code blocks in chat messages */
+.full-results-chat-text .chat-code-block-wrapper {
+  position: relative;
+  margin: 10px 0;
+}
+
+.full-results-chat-text .chat-code-block-wrapper pre {
+  margin: 0;
+  padding: 10px 12px 34px 12px;
+  border-radius: 8px;
+  background: rgba(40, 44, 52, 0.92);
+  color: #f5f8fa;
+  overflow-x: auto;
+}
+
+.full-results-chat-text .chat-code-block-wrapper code {
+  color: inherit;
+  background: transparent;
+  white-space: pre;
+}
+
+.full-results-chat-text .chat-code-copy-button {
+  position: absolute;
+  right: 8px;
+  bottom: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.4);
+  color: #f5f8fa;
+  font-size: 11px;
+  line-height: 1;
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.full-results-chat-text .chat-code-copy-button:hover {
+  background: rgba(0, 0, 0, 0.6);
 }
 
 /* Markdown table styling */
@@ -3970,6 +4006,28 @@ textarea.bp3-input.full-results-chat-input::-webkit-scrollbar-thumb:hover {
   padding: 8px;
   padding-left: 0px;
   background: transparent;
+}
+
+.full-results-chat-container .bp3-tooltip .bp3-popover-content {
+  padding: 4px 10px;
+}
+
+.full-results-chat-access-menu-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.full-results-chat-controls .full-results-chat-toolbar-button,
+.full-results-chat-input-container .full-results-chat-toolbar-button {
+  border-radius: 6px;
+  padding: 4px 6px;
+}
+
+.full-results-chat-controls .full-results-chat-toolbar-button:hover,
+.full-results-chat-input-container .full-results-chat-toolbar-button:hover,
+.bp3-popover-open .full-results-chat-toolbar-button {
+  background: rgba(58, 60, 61, 1) !important;
 }
 
 .full-results-chat-access-mode {

--- a/src/components/full-results-popup/components/chat/ChatHeader.tsx
+++ b/src/components/full-results-popup/components/chat/ChatHeader.tsx
@@ -190,7 +190,7 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
           {chatMessages.length > 0 && (
             <Tooltip content="Reset chat conversation">
               <Button
-                icon="trash"
+                icon="refresh"
                 onClick={() => {
                   // If only help messages, clear directly without confirmation
                   if (!hasRealMessages(chatMessages)) {

--- a/src/components/full-results-popup/components/chat/ChatInputArea.tsx
+++ b/src/components/full-results-popup/components/chat/ChatInputArea.tsx
@@ -7,6 +7,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import {
   Button,
+  Icon,
   Popover,
   Tag,
   Tooltip,
@@ -136,6 +137,11 @@ export const ChatInputArea: React.FC<ChatInputAreaProps> = ({
   const [textLengthAtSlashTrigger, setTextLengthAtSlashTrigger] = useState(0); // Track text length when / was typed
   const [isPageAutocompleteOpen, setIsPageAutocompleteOpen] = useState(false);
   const [pageAutocompleteQuery, setPageAutocompleteQuery] = useState("");
+  const [pageAutocompleteTrigger, setPageAutocompleteTrigger] = useState<
+    "double-bracket" | "hash" | null
+  >(null);
+  const [pageAutocompleteStartIndex, setPageAutocompleteStartIndex] =
+    useState(-1);
   const [isRecording, setIsRecording] = useState(false);
   const [isVoiceRecorderAvailable, setIsVoiceRecorderAvailable] =
     useState(false);
@@ -303,33 +309,50 @@ export const ChatInputArea: React.FC<ChatInputAreaProps> = ({
   };
 
   const handlePageSelect = (pageTitle: string) => {
-    // Find the [[ position and replace the incomplete link with completed one
-    const lastDoubleBracketIndex = chatInput.lastIndexOf("[[");
-    if (lastDoubleBracketIndex !== -1) {
-      const beforeBrackets = chatInput.substring(0, lastDoubleBracketIndex);
-      const newValue = `${beforeBrackets}[[${pageTitle}]]`;
-      onChatInputChange(newValue);
+    if (pageAutocompleteStartIndex === -1 || !pageAutocompleteTrigger) return;
 
-      // Close autocomplete
-      setIsPageAutocompleteOpen(false);
-      setPageAutocompleteQuery("");
+    const triggerLength = pageAutocompleteTrigger === "double-bracket" ? 2 : 1;
+    const replacement =
+      pageAutocompleteTrigger === "double-bracket"
+        ? `[[${pageTitle}]]`
+        : `#[[${pageTitle}]]`;
 
-      // Maintain focus on textarea
-      setTimeout(() => {
-        if (chatInputRef.current) {
-          chatInputRef.current.focus();
-          // Move cursor to end
-          chatInputRef.current.selectionStart = newValue.length;
-          chatInputRef.current.selectionEnd = newValue.length;
-        }
-      }, 0);
-    }
+    const replaceStart = pageAutocompleteStartIndex;
+    const replaceEnd =
+      pageAutocompleteStartIndex + triggerLength + pageAutocompleteQuery.length;
+    const newValue =
+      chatInput.substring(0, replaceStart) +
+      replacement +
+      chatInput.substring(replaceEnd);
+
+    onChatInputChange(newValue);
+
+    // Close autocomplete
+    setIsPageAutocompleteOpen(false);
+    setPageAutocompleteQuery("");
+    setPageAutocompleteTrigger(null);
+    setPageAutocompleteStartIndex(-1);
+
+    // Maintain focus on textarea
+    setTimeout(() => {
+      if (chatInputRef.current) {
+        chatInputRef.current.focus();
+        // Move cursor to end of inserted page reference
+        const cursorPosition = replaceStart + replacement.length;
+        chatInputRef.current.selectionStart = cursorPosition;
+        chatInputRef.current.selectionEnd = cursorPosition;
+      }
+    }, 0);
   };
 
   // Detect slash command trigger
-  const handleInputChange = (value: string) => {
+  const handleInputChange = (value: string, cursorPosition?: number) => {
     // Update parent state first
     onChatInputChange(value);
+    const textBeforeCursor = value.substring(
+      0,
+      cursorPosition ?? value.length,
+    );
 
     // If already in slash mode, track changes relative to the slash start position
     if (slashCommandMode && slashStartIndex !== -1) {
@@ -430,36 +453,85 @@ export const ChatInputArea: React.FC<ChatInputAreaProps> = ({
       }
     }
 
-    // Detect [[ for page autocomplete
-    const lastDoubleBracketIndex = value.lastIndexOf("[[");
+    // Detect page autocomplete triggers ([[ and #)
+    const pageAutocompleteCandidates: Array<{
+      trigger: "double-bracket" | "hash";
+      startIndex: number;
+      query: string;
+    }> = [];
+
+    // Trigger 1: [[page
+    const lastDoubleBracketIndex = textBeforeCursor.lastIndexOf("[[");
     const hasDoubleBracket = lastDoubleBracketIndex !== -1;
 
     if (hasDoubleBracket) {
       // Extract the part after the last "[["
-      const afterBrackets = value.substring(lastDoubleBracketIndex + 2);
+      const afterBrackets = textBeforeCursor.substring(lastDoubleBracketIndex + 2);
       const hasClosingBracket = afterBrackets.includes("]]");
       const hasSpace = afterBrackets.startsWith(" ");
 
       // Only open if there's at least one character and no space immediately after [[
       if (!hasClosingBracket && !hasSpace && afterBrackets.length > 0) {
-        if (!isPageAutocompleteOpen) {
-          setIsPageAutocompleteOpen(true);
-        }
-        // Update query and fetch pages
-        setPageAutocompleteQuery(afterBrackets);
-        onQueryPages(afterBrackets);
-      } else if (
-        isPageAutocompleteOpen &&
-        (hasClosingBracket || hasSpace || afterBrackets.length === 0)
-      ) {
-        // Close if user completed the link or added space or removed all text
-        setIsPageAutocompleteOpen(false);
-        setPageAutocompleteQuery("");
+        pageAutocompleteCandidates.push({
+          trigger: "double-bracket",
+          startIndex: lastDoubleBracketIndex,
+          query: afterBrackets,
+        });
       }
-    } else if (isPageAutocompleteOpen && !hasDoubleBracket) {
-      // Close if [[ was removed
+    }
+
+    // Trigger 2: #page
+    const lastHashIndex = textBeforeCursor.lastIndexOf("#");
+    const hasHash = lastHashIndex !== -1;
+
+    if (hasHash) {
+      const beforeHash = textBeforeCursor.substring(0, lastHashIndex);
+      const afterHash = textBeforeCursor.substring(lastHashIndex + 1);
+      const charBeforeHash =
+        lastHashIndex > 0 ? beforeHash.charAt(beforeHash.length - 1) : "";
+      const isPartOfWord = /[a-zA-Z0-9_]/.test(charBeforeHash);
+      const hasSpaceImmediatelyAfterHash = afterHash.startsWith(" ");
+      const hasBracketAfterHash = afterHash.startsWith("[[");
+      const isSingleHashToken = /^[^\s\[\]]+$/.test(afterHash);
+
+      if (
+        !isPartOfWord &&
+        !hasSpaceImmediatelyAfterHash &&
+        !hasBracketAfterHash &&
+        isSingleHashToken
+      ) {
+        pageAutocompleteCandidates.push({
+          trigger: "hash",
+          startIndex: lastHashIndex,
+          query: afterHash,
+        });
+      }
+    }
+
+    const activePageAutocomplete = pageAutocompleteCandidates.reduce<{
+      trigger: "double-bracket" | "hash";
+      startIndex: number;
+      query: string;
+    } | null>((latest, candidate) => {
+      if (!latest || candidate.startIndex > latest.startIndex) {
+        return candidate;
+      }
+      return latest;
+    }, null);
+
+    if (activePageAutocomplete) {
+      if (!isPageAutocompleteOpen) {
+        setIsPageAutocompleteOpen(true);
+      }
+      setPageAutocompleteQuery(activePageAutocomplete.query);
+      setPageAutocompleteTrigger(activePageAutocomplete.trigger);
+      setPageAutocompleteStartIndex(activePageAutocomplete.startIndex);
+      onQueryPages(activePageAutocomplete.query);
+    } else if (isPageAutocompleteOpen) {
       setIsPageAutocompleteOpen(false);
       setPageAutocompleteQuery("");
+      setPageAutocompleteTrigger(null);
+      setPageAutocompleteStartIndex(-1);
     }
   };
 
@@ -693,7 +765,12 @@ export const ChatInputArea: React.FC<ChatInputAreaProps> = ({
               content={
                 <Menu>
                   <MenuItem
-                    text="🛡️ Balanced"
+                    text={
+                      <span className="full-results-chat-access-menu-item">
+                        <Icon icon="shield" size={12} />
+                        Balanced
+                      </span>
+                    }
                     active={chatAccessMode === "Balanced"}
                     onClick={() => {
                       onAccessModeChange("Balanced");
@@ -701,7 +778,12 @@ export const ChatInputArea: React.FC<ChatInputAreaProps> = ({
                     }}
                   />
                   <MenuItem
-                    text="🔓 Full Access"
+                    text={
+                      <span className="full-results-chat-access-menu-item">
+                        <Icon icon="unlock" size={12} />
+                        Full Access
+                      </span>
+                    }
                     active={chatAccessMode === "Full Access"}
                     onClick={() => {
                       onAccessModeChange("Full Access");
@@ -763,12 +845,12 @@ export const ChatInputArea: React.FC<ChatInputAreaProps> = ({
               <Button
                 minimal
                 small
+                className="full-results-chat-toolbar-button"
+                icon={chatAccessMode === "Balanced" ? "shield" : "unlock"}
                 text={
-                  chatAccessMode === "Balanced"
-                    ? "🛡️"
-                    : noTruncation
-                      ? "🔓∞"
-                      : "🔓"
+                  chatAccessMode === "Full Access" && noTruncation
+                    ? "∞"
+                    : undefined
                 }
               />
             </Popover>
@@ -836,6 +918,7 @@ export const ChatInputArea: React.FC<ChatInputAreaProps> = ({
               <Button
                 minimal
                 small
+                className="full-results-chat-toolbar-button"
                 icon="style"
                 intent={isPinnedStyle ? "primary" : "none"}
               />
@@ -939,6 +1022,7 @@ export const ChatInputArea: React.FC<ChatInputAreaProps> = ({
               <Button
                 minimal
                 small
+                className="full-results-chat-toolbar-button"
                 icon="rocket"
                 onClick={() => {
                   if (!slashCommandMode) {
@@ -973,7 +1057,13 @@ export const ChatInputArea: React.FC<ChatInputAreaProps> = ({
               }
               placement="top"
             >
-              <Button minimal small icon="cog" text={selectedModel} />
+              <Button
+                minimal
+                small
+                className="full-results-chat-toolbar-button"
+                icon="cog"
+                text={selectedModel}
+              />
             </Popover>
           </div>
         </Tooltip>
@@ -1025,7 +1115,7 @@ export const ChatInputArea: React.FC<ChatInputAreaProps> = ({
             <Button
               minimal
               small
-              className="full-results-chat-mic-button"
+              className="full-results-chat-mic-button full-results-chat-toolbar-button"
               onClick={isRecording ? handleTranscribeClick : handleMicClick}
               disabled={isTyping}
             >
@@ -1045,6 +1135,8 @@ export const ChatInputArea: React.FC<ChatInputAreaProps> = ({
             if (!nextOpenState) {
               setIsPageAutocompleteOpen(false);
               setPageAutocompleteQuery("");
+              setPageAutocompleteTrigger(null);
+              setPageAutocompleteStartIndex(-1);
             }
           }}
           content={
@@ -1064,10 +1156,13 @@ export const ChatInputArea: React.FC<ChatInputAreaProps> = ({
         >
           <textarea
             ref={chatInputRef}
-            placeholder="Write your prompt... (type / for commands, [[ for pages)"
+            placeholder="Write your prompt... (type / for commands, [[ or # for pages)"
             value={chatInput}
             onChange={(e) => {
-              handleInputChange(e.target.value);
+              handleInputChange(
+                e.target.value,
+                e.target.selectionStart ?? e.target.value.length,
+              );
               // Auto-resize textarea
               e.target.style.height = "auto";
               e.target.style.height = e.target.scrollHeight + "px";

--- a/src/components/full-results-popup/components/chat/ChatPageAutocomplete.tsx
+++ b/src/components/full-results-popup/components/chat/ChatPageAutocomplete.tsx
@@ -1,7 +1,7 @@
 /**
  * Chat Page Autocomplete Component
  *
- * Displays a filtered list of page titles for autocompletion when user types [[
+ * Displays a filtered list of page titles for autocompletion when user types [[ or #
  */
 
 import React from "react";

--- a/src/components/full-results-popup/components/chat/ChatToolsMenu.tsx
+++ b/src/components/full-results-popup/components/chat/ChatToolsMenu.tsx
@@ -570,7 +570,13 @@ export const ChatToolsMenu: React.FC<ChatToolsMenuProps> = ({
         placement="top"
         minimal
       >
-        <Button minimal small icon={iconName} intent={iconIntent} />
+        <Button
+          minimal
+          small
+          className="full-results-chat-toolbar-button"
+          icon={iconName}
+          intent={iconIntent}
+        />
       </Popover>
     </Tooltip>
   );

--- a/src/components/full-results-popup/components/chat/FullResultsChat.tsx
+++ b/src/components/full-results-popup/components/chat/FullResultsChat.tsx
@@ -956,6 +956,49 @@ export const FullResultsChat: React.FC<FullResultsChatProps> = ({
     const handleBlockRefClick = (event: MouseEvent) => {
       const target = event.target as HTMLElement;
 
+      // Handle code block copy button
+      const codeCopyButton = target.closest(
+        ".chat-code-copy-button",
+      ) as HTMLButtonElement | null;
+      if (codeCopyButton) {
+        event.preventDefault();
+        event.stopPropagation();
+
+        const codeBlockWrapper = codeCopyButton.closest(
+          ".chat-code-block-wrapper",
+        );
+        const codeElement = codeBlockWrapper?.querySelector("code");
+        const codeText = codeElement?.textContent ?? "";
+
+        if (!codeText) {
+          AppToaster.show({
+            message: "No code found to copy.",
+            intent: "warning",
+            timeout: 1500,
+          });
+          return;
+        }
+
+        navigator.clipboard
+          .writeText(codeText)
+          .then(() => {
+            AppToaster.show({
+              message: "Copied to clipboard!",
+              intent: "success",
+              timeout: 1500,
+            });
+          })
+          .catch((error) => {
+            console.error("Failed to copy code block:", error);
+            AppToaster.show({
+              message: "Failed to copy code block.",
+              intent: "danger",
+              timeout: 2000,
+            });
+          });
+        return;
+      }
+
       // Only handle Roam-specific links, let external links work normally
       if (target.classList.contains("roam-block-ref-chat")) {
         event.preventDefault();

--- a/src/components/full-results-popup/utils/chatMessageUtils.ts
+++ b/src/components/full-results-popup/utils/chatMessageUtils.ts
@@ -158,8 +158,9 @@ export const renderMarkdown = (text: string): string => {
     (_match, language, code) => {
       const index = codeBlocks.length;
       const langClass = language ? ` class="language-${language}"` : "";
+      const escapedCode = escapeHtml(code.trim());
       codeBlocks.push(
-        `<pre><code${langClass}>${escapeHtml(code.trim())}</code></pre>`
+        `<div class="chat-code-block-wrapper"><pre><code${langClass}>${escapedCode}</code></pre><button type="button" class="chat-code-copy-button" aria-label="Copy code block" title="Copy code">Copy</button></div>`
       );
       return `${codeBlockPlaceholder}${index}`;
     }
@@ -454,7 +455,7 @@ export const renderMarkdown = (text: string): string => {
   });
 
   // Wrap in paragraphs (but not if it starts with a header, list, blockquote, hr, or table)
-  if (!rendered.match(/^<(h[1-6]|ul|ol|pre|blockquote|hr|table)/)) {
+  if (!rendered.match(/^<(h[1-6]|ul|ol|pre|blockquote|hr|table|div)/)) {
     rendered = "<p>" + rendered + "</p>";
   }
   rendered = rendered.replace(/<p><\/p>/g, "");
@@ -473,6 +474,9 @@ export const renderMarkdown = (text: string): string => {
       "style",
       "src",
       "alt",
+      "type",
+      "aria-label",
+      "title",
     ],
     ADD_TAGS: [
       "code",
@@ -490,6 +494,7 @@ export const renderMarkdown = (text: string): string => {
       "h5",
       "h6",
       "img",
+      "button",
     ],
     ALLOWED_URI_REGEXP:
       /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|www):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,


### PR DESCRIPTION
## Summary
This PR implements a set of UX polish improvements in the Live AI chat UI and markdown rendering, based on integration notes.

## Changes
- Changed the chat reset action icon from `trash` to `refresh` to better match "restart conversation" semantics.
- Added a copy button to rendered markdown code blocks.
- Added clipboard copy behavior for code blocks with Blueprint toast feedback (`Copied to clipboard!`).
- Added default tooltip content padding (`4px 10px`) scoped to the chat container.
- Standardized hover background and control padding for chat toolbar buttons (tools, prompts, mic, style, model).
- Replaced access-mode emoji labels/icons with Blueprint icons:
- `Balanced` now uses `shield`.
- `Full Access` now uses `unlock`.
- Kept no-truncation indicator as `∞` text when enabled.
- Removed the yellow help-callout hover dim/brighten behavior so callouts remain visually stable.
- Added page autocomplete support for `#` triggers in chat input (in addition to `[[`).
- Selecting a page from `#query` now inserts `#[[Page Title]]`.
- Updated autocomplete behavior to track cursor position and close correctly when token boundaries are reached.

## Stability / follow-up fixes included
- Prevented hash autocomplete from staying open after a completed token (avoids Enter-key hijacking).
- Fixed paragraph wrapping edge case for code-block wrapper divs.
- Scoped tooltip padding to chat UI to avoid global Blueprint tooltip side effects.
