### PR TITLE
Support transactional Roam Grid table completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Please report any issue [here](https://github.com/fbgallet/roam-extension-live-a
 ### New in v.33 (July, 2026)
 
 - 🆕 **Roam table auto-complete**: click a Roam table's row/column handle (or right-click on its "+" buttons) to fill empty or `[placeholder/instructions]` cells, generate whole new rows & columns with AI, or update whole row or column according to your instructions.
+- Enhanced Roam Grid tables use the Grid transaction API when available, while ordinary Roam tables retain the native block fallback. See [the integration contract](docs/roam-grid-integration.md).
 
 (See complete changelog [here](https://github.com/fbgallet/roam-extension-speech-to-roam/blob/main/CHANGELOG.md))
 

--- a/docs/roam-grid-integration.md
+++ b/docs/roam-grid-integration.md
@@ -1,0 +1,26 @@
+# Roam Grid integration
+
+Live AI table completion remains native-first and adds an optional compatibility bridge for enhanced Roam Grid tables.
+
+## Read path
+
+When `window.roamGrid.v1.getTableModel(tableUid)` is available and returns an enhanced table, Live AI reads the UID-backed raw cell strings from that model. Raw strings remain the values used for placeholder detection and writes; resolved block-reference text is used only in the model prompt.
+
+If Roam Grid is unavailable, the table is not enhanced, or its model call fails during reload, Live AI immediately falls back to its existing native Roam block-chain reader.
+
+## Write path
+
+Generated values for an enhanced table are serialized through:
+
+```js
+window.roamGrid.v1.applyPatch(tableUid, {
+  op: "set",
+  row,
+  col,
+  value,
+});
+```
+
+This keeps Roam Grid's optimistic model, formulas, undo history, and persistence lane coherent. Native tables continue to use `roamAlphaAPI.updateBlock`. If Roam Grid unloads while a streamed completion is running, the write safely uses that native fallback.
+
+The adapter is additive: Live AI does not require Roam Grid, change native table storage, or take ownership of Roam Grid's metadata.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "AI assistant tailor-made for Roam",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test test/*.test.cjs",
     "dev": "npx roamjs-scripts dev --depot"
   },
   "keywords": [],

--- a/src/ai/tableCompletion.js
+++ b/src/ai/tableCompletion.js
@@ -16,6 +16,7 @@ import { AppToaster } from "../components/Toaster";
 import { extensionStorage } from "..";
 import { defaultAssistantCharacter } from "./prompts";
 import { hasTrueBooleanKey } from "../utils/dataProcessing";
+const { updateTableCell } = require("../utils/roamGridBridge.cjs");
 
 // The completion streams back one line per cell so we can fill cells progressively.
 const LINE_FORMAT_INSTRUCTIONS = `\n\nOUTPUT FORMAT — this is strict. Return ONLY the cells to fill, one per line, each line formatted EXACTLY as:
@@ -205,14 +206,13 @@ async function runTableCompletion({
     // formula dependencies, undo history, metadata, and serialized Roam writes
     // stay coherent. Native tables retain the existing direct-block fallback.
     writeQueue = writeQueue.then(() =>
-      roamGrid && c && window.roamGrid?.v1?.applyPatch
-        ? window.roamGrid.v1.applyPatch(tableBlockUid, {
-            op: "set",
-            row: c.row,
-            col: c.col,
-            value,
-          })
-        : window.roamAlphaAPI.updateBlock({ block: { uid, string: value } })
+      updateTableCell({
+        tableBlockUid,
+        coordinate: c,
+        uid,
+        value,
+        roamGrid,
+      })
     );
     spinners.remove(uid);
     if (c) revealCells(tableBlockUid, [{ row: c.row, col: c.col }]);

--- a/src/ai/tableCompletion.js
+++ b/src/ai/tableCompletion.js
@@ -176,6 +176,7 @@ async function runTableCompletion({
   model,
   cleanupUids,
   coords,
+  roamGrid = false,
   thinkingEnabled,
   boldUids,
 }) {
@@ -187,6 +188,7 @@ async function runTableCompletion({
   );
   const boldSet = new Set((boldUids || []).map(stripUidParens));
   const appliedUids = new Set();
+  let writeQueue = Promise.resolve();
 
   // Write one cell as soon as its "((uid)): value" line has fully arrived.
   const applyCell = (rawUid, rawValue) => {
@@ -198,9 +200,21 @@ async function runTableCompletion({
       value = `**${value}**`;
     }
     appliedUids.add(uid);
-    window.roamAlphaAPI.updateBlock({ block: { uid, string: value } });
-    spinners.remove(uid);
     const c = coordByUid.get(uid);
+    // Enhanced tables must go through Roam Grid so its optimistic model,
+    // formula dependencies, undo history, metadata, and serialized Roam writes
+    // stay coherent. Native tables retain the existing direct-block fallback.
+    writeQueue = writeQueue.then(() =>
+      roamGrid && c && window.roamGrid?.v1?.applyPatch
+        ? window.roamGrid.v1.applyPatch(tableBlockUid, {
+            op: "set",
+            row: c.row,
+            col: c.col,
+            value,
+          })
+        : window.roamAlphaAPI.updateBlock({ block: { uid, string: value } })
+    );
+    spinners.remove(uid);
     if (c) revealCells(tableBlockUid, [{ row: c.row, col: c.col }]);
   };
 
@@ -239,6 +253,7 @@ async function runTableCompletion({
         if (m) applyCell(m[1], m[2]);
       });
     }
+    await writeQueue;
 
     if (appliedUids.size) {
       AppToaster.show({
@@ -343,7 +358,7 @@ export async function autoCompleteTableRow({
     graphContext,
   });
   const coords = targetCells.map((c) => ({ row: rowIndex, col: c.col, uid: c.uid }));
-  await runTableCompletion({ tableBlockUid, prompt, systemPrompt, model, coords, thinkingEnabled });
+  await runTableCompletion({ tableBlockUid, prompt, systemPrompt, model, coords, roamGrid: model2d.roamGrid, thinkingEnabled });
 }
 
 /**
@@ -427,7 +442,7 @@ export async function autoCompleteTableColumn({
     graphContext,
   });
   const coords = targetCells.map((c) => ({ row: c.row, col: colIndex, uid: c.uid }));
-  await runTableCompletion({ tableBlockUid, prompt, systemPrompt, model, coords, thinkingEnabled });
+  await runTableCompletion({ tableBlockUid, prompt, systemPrompt, model, coords, roamGrid: model2d.roamGrid, thinkingEnabled });
 }
 
 /**
@@ -511,6 +526,7 @@ export async function generateTableRows({
     model,
     cleanupUids: createdRowUids,
     coords,
+    roamGrid: model2d.roamGrid,
     thinkingEnabled,
   });
 }
@@ -595,6 +611,7 @@ export async function generateTableColumns({
     model,
     cleanupUids,
     coords,
+    roamGrid: model2d.roamGrid,
     thinkingEnabled,
     boldUids,
   });

--- a/src/utils/roamGridBridge.cjs
+++ b/src/utils/roamGridBridge.cjs
@@ -1,0 +1,68 @@
+function currentWindow() {
+  return typeof window === "undefined" ? undefined : window;
+}
+
+/**
+ * Read an opted-in Roam Grid table through its public API. Returning null is
+ * intentional: callers can continue through Live AI's native-table reader.
+ */
+function getEnhancedTableModel(
+  tableBlockUid,
+  resolveReferences,
+  apiRoot = currentWindow()
+) {
+  try {
+    const enhanced = apiRoot?.roamGrid?.v1?.getTableModel?.(tableBlockUid);
+    if (!enhanced?.rows?.length) return null;
+    const rows = enhanced.rows.map((row) =>
+      row.map((cell) => {
+        const raw = cell?.raw ?? "";
+        return {
+          uid: cell?.uid,
+          content: raw,
+          display: resolveReferences(raw),
+        };
+      })
+    );
+    return {
+      tableUid: tableBlockUid,
+      rows,
+      colCount:
+        enhanced.columnIds?.length ||
+        rows.reduce((max, row) => Math.max(max, row.length), 0),
+      roamGrid: true,
+    };
+  } catch (error) {
+    console.warn(
+      "Live AI table: Roam Grid adapter failed; using native blocks",
+      error
+    );
+    return null;
+  }
+}
+
+/**
+ * Keep enhanced-table writes transactional. If the table is native, or the
+ * extension disappeared during a streamed completion, retain the established
+ * direct-block update path.
+ */
+function updateTableCell({
+  tableBlockUid,
+  coordinate,
+  uid,
+  value,
+  roamGrid,
+  apiRoot = currentWindow(),
+}) {
+  if (roamGrid && coordinate && apiRoot?.roamGrid?.v1?.applyPatch) {
+    return apiRoot.roamGrid.v1.applyPatch(tableBlockUid, {
+      op: "set",
+      row: coordinate.row,
+      col: coordinate.col,
+      value,
+    });
+  }
+  return apiRoot.roamAlphaAPI.updateBlock({ block: { uid, string: value } });
+}
+
+module.exports = { getEnhancedTableModel, updateTableCell };

--- a/src/utils/roamTable.js
+++ b/src/utils/roamTable.js
@@ -63,6 +63,36 @@ function getColumnChain(rowBlock) {
  * is { uid, content }. Returns null if the block can't be read.
  */
 export function getTableModel(tableBlockUid) {
+  // Roam Grid keeps enhanced native tables backed by these same block UIDs, but
+  // its public model is already normalized and includes cells that may be
+  // temporarily virtualized out of the DOM. Prefer that model when available;
+  // fall back to the native outline reader when Roam Grid is absent or the table
+  // has not opted in.
+  try {
+    const enhanced = window.roamGrid?.v1?.getTableModel?.(tableBlockUid);
+    if (enhanced?.rows?.length) {
+      const rows = enhanced.rows.map((row) =>
+        row.map((cell) => {
+          const raw = cell?.raw ?? "";
+          return {
+            uid: cell?.uid,
+            content: raw,
+            display: resolveReferences(raw),
+          };
+        })
+      );
+      return {
+        tableUid: tableBlockUid,
+        rows,
+        colCount:
+          enhanced.columnIds?.length ||
+          rows.reduce((max, row) => Math.max(max, row.length), 0),
+        roamGrid: true,
+      };
+    }
+  } catch (error) {
+    console.warn("Live AI table: Roam Grid adapter failed; using native blocks", error);
+  }
   const root = getTreeByUid(tableBlockUid)?.[0];
   if (!root) return null;
   const rowBlocks = sortByOrder(root.children);

--- a/src/utils/roamTable.js
+++ b/src/utils/roamTable.js
@@ -4,6 +4,7 @@ import {
   getBlockOrderByUid,
   resolveReferences,
 } from "./roamAPI";
+const { getEnhancedTableModel } = require("./roamGridBridge.cjs");
 
 // A Roam table is a block whose string is `{{[[table]]}}`. Its children encode the
 // grid: each direct child (sorted by :block/order) is a ROW, and within a row the
@@ -68,31 +69,8 @@ export function getTableModel(tableBlockUid) {
   // temporarily virtualized out of the DOM. Prefer that model when available;
   // fall back to the native outline reader when Roam Grid is absent or the table
   // has not opted in.
-  try {
-    const enhanced = window.roamGrid?.v1?.getTableModel?.(tableBlockUid);
-    if (enhanced?.rows?.length) {
-      const rows = enhanced.rows.map((row) =>
-        row.map((cell) => {
-          const raw = cell?.raw ?? "";
-          return {
-            uid: cell?.uid,
-            content: raw,
-            display: resolveReferences(raw),
-          };
-        })
-      );
-      return {
-        tableUid: tableBlockUid,
-        rows,
-        colCount:
-          enhanced.columnIds?.length ||
-          rows.reduce((max, row) => Math.max(max, row.length), 0),
-        roamGrid: true,
-      };
-    }
-  } catch (error) {
-    console.warn("Live AI table: Roam Grid adapter failed; using native blocks", error);
-  }
+  const enhanced = getEnhancedTableModel(tableBlockUid, resolveReferences);
+  if (enhanced) return enhanced;
   const root = getTreeByUid(tableBlockUid)?.[0];
   if (!root) return null;
   const rowBlocks = sortByOrder(root.children);

--- a/test/roam-grid-adapter.test.cjs
+++ b/test/roam-grid-adapter.test.cjs
@@ -1,0 +1,119 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  getEnhancedTableModel,
+  updateTableCell,
+} = require("../src/utils/roamGridBridge.cjs");
+
+test("enhanced tables are read through Roam Grid with raw UID-backed cells", () => {
+  const apiRoot = {
+    roamGrid: {
+      v1: {
+        getTableModel: (uid) => {
+          assert.equal(uid, "table-uid");
+          return {
+            columnIds: ["a", "b"],
+            rows: [[{ uid: "cell-1", raw: "((source))" }, { uid: "cell-2", raw: "" }]],
+          };
+        },
+      },
+    },
+  };
+
+  const model = getEnhancedTableModel(
+    "table-uid",
+    (raw) => (raw === "((source))" ? "Resolved source" : raw),
+    apiRoot
+  );
+
+  assert.equal(model.roamGrid, true);
+  assert.equal(model.colCount, 2);
+  assert.deepEqual(model.rows[0][0], {
+    uid: "cell-1",
+    content: "((source))",
+    display: "Resolved source",
+  });
+});
+
+test("missing, unenhanced, and failed Grid reads return null for native fallback", () => {
+  assert.equal(getEnhancedTableModel("table-uid", String, {}), null);
+  assert.equal(
+    getEnhancedTableModel("table-uid", String, {
+      roamGrid: { v1: { getTableModel: () => ({ rows: [] }) } },
+    }),
+    null
+  );
+  const previousWarn = console.warn;
+  console.warn = () => {};
+  try {
+    assert.equal(
+      getEnhancedTableModel("table-uid", String, {
+        roamGrid: { v1: { getTableModel: () => { throw new Error("reload"); } } },
+      }),
+      null
+    );
+  } finally {
+    console.warn = previousWarn;
+  }
+});
+
+test("enhanced completion writes use one transactional Grid patch", async () => {
+  const calls = [];
+  const apiRoot = {
+    roamGrid: {
+      v1: {
+        applyPatch: async (...args) => calls.push(args),
+      },
+    },
+    roamAlphaAPI: { updateBlock: () => assert.fail("native writer called") },
+  };
+
+  await updateTableCell({
+    tableBlockUid: "table-uid",
+    coordinate: { row: 3, col: 4 },
+    uid: "cell-uid",
+    value: "Paris",
+    roamGrid: true,
+    apiRoot,
+  });
+
+  assert.deepEqual(calls, [["table-uid", { op: "set", row: 3, col: 4, value: "Paris" }]]);
+});
+
+test("native tables retain direct block updates", async () => {
+  const calls = [];
+  const apiRoot = {
+    roamAlphaAPI: {
+      updateBlock: async (update) => calls.push(update),
+    },
+  };
+
+  await updateTableCell({
+    tableBlockUid: "table-uid",
+    coordinate: { row: 0, col: 0 },
+    uid: "cell-uid",
+    value: "Native value",
+    roamGrid: false,
+    apiRoot,
+  });
+
+  assert.deepEqual(calls, [{ block: { uid: "cell-uid", string: "Native value" } }]);
+});
+
+test("Grid disappearance during streaming falls back to the native writer", async () => {
+  const calls = [];
+  const apiRoot = {
+    roamAlphaAPI: { updateBlock: async (update) => calls.push(update) },
+  };
+
+  await updateTableCell({
+    tableBlockUid: "table-uid",
+    coordinate: { row: 1, col: 2 },
+    uid: "cell-uid",
+    value: "Recovered",
+    roamGrid: true,
+    apiRoot,
+  });
+
+  assert.equal(calls[0].block.string, "Recovered");
+});


### PR DESCRIPTION
## Summary
- detect enhanced Roam Grid tables through window.roamGrid.v1
- read table models through the public adapter API
- apply generated cell updates transactionally while preserving native-table fallback
- add focused adapter tests and integration documentation

## Verification
- focused adapter suite: 5/5 passing
- existing native-table behavior remains the fallback when Roam Grid is unavailable